### PR TITLE
Initial commit of adjoint ODE stuff.

### DIFF
--- a/stan/math/rev/core/vari.hpp
+++ b/stan/math/rev/core/vari.hpp
@@ -58,16 +58,25 @@ namespace stan {
       explicit vari(double x):
         val_(x),
         adj_(0.0) {
+        // This is a hack to try to lessen the amount of segfaults that come
+        // up when using nested reverse mode autodiff inside a chain
+        // (this vector might get reallocated as vars are added to it)
+        ChainableStack::var_stack_.reserve(10000);
         ChainableStack::var_stack_.push_back(this);
       }
 
       vari(double x, bool stacked):
         val_(x),
         adj_(0.0) {
-        if (stacked)
+        if (stacked) {
+          // See comment for reserve in vari(double) constructor
+          ChainableStack::var_stack_.reserve(10000);
           ChainableStack::var_stack_.push_back(this);
-        else
+        } else {
+          // See comment for reserve in vari(double) constructor
+          ChainableStack::var_stack_.reserve(10000);
           ChainableStack::var_nochain_stack_.push_back(this);
+        }
       }
 
       /**

--- a/stan/math/rev/mat/fun/build_ode_varis.hpp
+++ b/stan/math/rev/mat/fun/build_ode_varis.hpp
@@ -1,0 +1,120 @@
+#ifndef STAN_MATH_REV_MAT_FUN_BUILD_ODE_VARIS_HPP
+#define STAN_MATH_REV_MAT_FUN_BUILD_ODE_VARIS_HPP
+
+#include <stan/math/rev/mat/fun/ode_vari.hpp>
+#include <stan/math/prim/scal/meta/return_type.hpp>
+#include <algorithm>
+#include <ostream>
+#include <vector>
+
+namespace stan {
+  namespace math {
+    /*
+     * build_ode_varis takes the CVODES output and wraps it in a 2D Stan array
+     * of vars. To avoiding chain for every individual output, we create
+     * one giant ode_vari which does the actual adjoint calculation and then
+     * num_timesteps * num_states - 1 varis which are just placeholders.
+     *
+     * Because all the varis are pushed onto the stack at once, whenever any of
+     * them are called, all the adjoints at these outputs are ready to be
+     * chained back up.
+     *
+     * By putting all but one vari on the autodiff stack, only one vari gets
+     * called and one one backwards ODE solve needs to happen
+     *
+     * @tparam T_ode_data Convenience template to hide true type of cvodes_data
+     * @tparam T_initial Type of initial conditions, can be double or var
+     * @tparam T_param Type of parameters, can be double or var
+     * @param t0 Initial time for forward ODE solve
+     * @param relative_tolerance Relative tolerance of adjoint ODE solve
+     * @param absolute_tolerance Absolute tolerance of adjoint ODE solve
+     * @param y Output of forward ODE solve
+     * @param y0_ Initial conditions for forward ODE solve
+     * @param theta_ Parameters for forward ODE solve
+     * @param ts Time steps to produce output in forward ODE solve
+     * @param cvodes_mem Pointer to CVODES internal memory space
+     * @param cvodes_data Pointer to cvodes_ode_data struct that computes
+     *   jacobians and such
+     */
+    template <typename T_ode_data, typename T_initial, typename T_param>
+    inline
+    std::vector<std::vector<typename stan::return_type<T_initial,
+                                                       T_param>::type> >
+    build_ode_varis(double t0,
+                    double relative_tolerance,
+                    double absolute_tolerance,
+                    const std::vector<std::vector<double> >& y,
+                    const std::vector<T_initial>& y0_,
+                    const std::vector<T_param>& theta_,
+                    const std::vector<double> &ts,
+                    void* cvodes_mem,
+                    T_ode_data *cvodes_data) {
+      using std::vector;
+
+      const size_t N = y0_.size();
+
+      vector<var> y0(y0_.begin(), y0_.end());
+      vector<var> theta(theta_.begin(), theta_.end());
+      vector<vector<var> > y_return(y.size(), vector<var>(N, 0));
+
+      vari** non_chaining_varis =
+        ChainableStack::memalloc_.alloc_array<vari*>(y.size() * N - 1);
+
+      for (size_t i = 0; i < y.size(); i++) {
+        for (size_t j = 0; j < N; j++) {
+          // The special vari that will handle the adjoint solve corresponds to
+          // the output y[y.size() - 1][N - 1]
+          if (i == y.size() - 1 && j == N - 1)
+            continue;
+
+          // non_chaining_varis[i * N + j] corresponds to the vari attached to
+          // the ode output at time t[i] and state j
+          non_chaining_varis[i * N + j] = new vari(y[i][j], false);
+        }
+      }
+
+      ode_vari<T_ode_data>* ode_vari_ =
+        new ode_vari<T_ode_data>(t0,
+                                 relative_tolerance,
+                                 absolute_tolerance,
+                                 y[y.size() - 1][N - 1],
+                                 y0,
+                                 theta,
+                                 ts,
+                                 non_chaining_varis,
+                                 cvodes_mem,
+                                 cvodes_data);
+
+      for (size_t i = 0; i < y.size(); i++)
+        for (size_t j = 0; j < N; j++)
+          // Inject our special vari at y[y.size() - 1][N - 1]
+          if (i == y.size() - 1 && j == N - 1)
+            y_return[i][j] = var(ode_vari_);
+          else
+            y_return[i][j] = var(non_chaining_varis[i * N + j]);
+
+      return y_return;
+    }
+
+    /*
+     * If theta and y are both doubles, just pass the values through (there's
+     * no autodiff to handle here).
+     */
+    template <typename T_ode_data>
+    inline
+    std::vector<std::vector<double> >
+    build_ode_varis(double t0,
+                    double relative_tolerance,
+                    double absolute_tolerance,
+                    const std::vector<std::vector<double> >& y,
+                    const std::vector<double>& y0,
+                    const std::vector<double>& theta,
+                    const std::vector<double> &ts,
+                    void* cvodes_mem,
+                    T_ode_data *cvodes_data) {
+      return y;
+    }
+  }
+}
+
+#endif

--- a/stan/math/rev/mat/fun/ode_vari.hpp
+++ b/stan/math/rev/mat/fun/ode_vari.hpp
@@ -1,0 +1,187 @@
+#ifndef STAN_MATH_REV_MAT_FUN_ODE_VARI_HPP
+#define STAN_MATH_REV_MAT_FUN_ODE_VARI_HPP
+
+#include <stan/math/rev/mat/functor/cvodes_ode_data.hpp>
+#include <cvodes/cvodes.h>
+#include <cvodes/cvodes_lapack.h>
+#include <cvodes/cvodes_dense.h>
+#include <nvector/nvector_serial.h>
+#include <ostream>
+#include <vector>
+
+namespace stan {
+  namespace math {
+    /*
+     * ode_vari is the special vari that will handle running the adjoint ODE
+     * for all the other varis
+     *
+     * @tparam T_ode_data Type of cvodes_ode_data structure
+     */
+    template <typename T_ode_data>
+    class ode_vari : public vari {
+    protected:
+      double t0_;
+      int N_;
+      int M_;
+      double relative_tolerance_;
+      double absolute_tolerance_;
+      vari** initial_v_;
+      vari** theta_v_;
+      std::vector<double> ts_;
+      vari** non_chaining_varis_;
+      void* cvodes_mem_;
+      T_ode_data* cvodes_data_;
+
+    public:
+    /*
+     * ode_vari is the special vari that handles running the adjoint ODE.
+     * For each ODE solve, there is only one ode_vari
+     *
+     * @param t0 Initial time for forward ODE solve
+     * @param relative_tolerance Relative tolerance of adjoint ODE solve
+     * @param absolute_tolerance Absolute tolerance of adjoint ODE solve
+     * @param y Output of forward ODE solve
+     * @param y0_ Initial conditions for forward ODE solve
+     * @param theta_ Parameters for forward ODE solve
+     * @param ts Time steps to produce output in forward ODE solve
+     * @param cvodes_mem Pointer to CVODES internal memory space
+     * @param cvodes_data Pointer to cvodes_ode_data struct that computes
+     *   jacobians and such
+     */
+      explicit ode_vari(double t0,
+                        double relative_tolerance,
+                        double absolute_tolerance,
+                        double value,
+                        const std::vector<var> &initial,
+                        const std::vector<var> &theta,
+                        const std::vector<double> &ts,
+                        vari** non_chaining_varis,
+                        void* cvodes_mem,
+                        T_ode_data *cvodes_data)
+        : vari(value),
+          t0_(t0),
+          N_(initial.size()),
+          M_(theta.size()),
+          relative_tolerance_(relative_tolerance),
+          absolute_tolerance_(absolute_tolerance),
+          initial_v_(reinterpret_cast<vari**>(ChainableStack::memalloc_
+                                              .alloc(initial.size() *
+                                                     sizeof(vari *)))),
+          theta_v_(reinterpret_cast<vari**>(ChainableStack::memalloc_
+                                            .alloc(theta.size() *
+                                                   sizeof(vari *)))),
+          ts_(ts),
+          non_chaining_varis_(non_chaining_varis),
+          cvodes_mem_(cvodes_mem),
+          cvodes_data_(cvodes_data) {
+        // These are the input parameters, so we'll need to increment these
+        // adjoints
+        for (size_t i = 0; i < N_; i++)
+          initial_v_[i] = initial[i].vi_;
+        for (size_t i = 0; i < M_; i++)
+          theta_v_[i] = theta[i].vi_;
+      }
+
+      virtual void chain() {
+        // std::cout << "chain" << std::endl; <-- Good way to verify it's only
+        //  being called once
+        N_Vector cvodes_state_sens(N_VNew_Serial(N_ + M_));
+        N_VConst(0.0, cvodes_state_sens);
+
+        try {
+          int indexB;
+          // This is all boilerplate CVODES setting up the adjoint ODE to solve
+          // CV_ADAMS seemed to work better than CV_BDF on the toy problem
+          // I was playing with.
+          cvodes_check_flag(CVodeCreateB
+                            (cvodes_mem_, CV_ADAMS, CV_NEWTON, &indexB),
+                            "CVodeCreateB");
+
+          cvodes_check_flag(CVodeSetUserDataB
+                            (cvodes_mem_, indexB,
+                             reinterpret_cast<void*>(cvodes_data_)),
+                            "CVodeSetUserDataB");
+
+          // The ode_rhs_adj_sense functions passed in here cause problems with
+          // the autodiff stack (they can cause reallocations of the internal
+          // vectors and cause segfaults)
+          cvodes_check_flag(CVodeInitB(cvodes_mem_,
+                                       indexB,
+                                       &T_ode_data::ode_rhs_adj_sens,
+                                       ts_.back(),
+                                       cvodes_state_sens),
+                            "CVodeInitB");
+
+          cvodes_check_flag(CVodeSStolerancesB(cvodes_mem_,
+                                               indexB,
+                                               relative_tolerance_,
+                                               absolute_tolerance_),
+                            "CVodeSStolerancesB");
+
+          cvodes_check_flag(CVDenseB(cvodes_mem_, indexB, N_ + M_),
+                            "CVDenseB");
+
+          // The same autodiff issue that applies to doe_rhs_adj_sense applies
+          // here
+          cvodes_check_flag(CVDlsSetDenseJacFnB
+                            (cvodes_mem_, indexB,
+                             &T_ode_data::dense_jacobian_adj),
+                            "CVDlsSetDenseJacFnB");
+
+          // At every time step, collect the adjoints from the output
+          // variables and re-initialize the solver
+          for (int i = ts_.size() - 1; i >= 0; --i) {
+            // Take in the adjoints from all the output variables at this point
+            // in time
+            for (int j = 0; j < N_; j++) {
+              if (i == ts_.size() - 1 && j == N_ - 1) {
+                NV_Ith_S(cvodes_state_sens, j) += adj_;
+              } else {
+                NV_Ith_S(cvodes_state_sens, j) +=
+                  non_chaining_varis_[i * N_ + j]->adj_;
+              }
+            }
+
+            cvodes_check_flag(CVodeReInitB(cvodes_mem_, indexB, ts_[i],
+                                           cvodes_state_sens),
+                              "CVodeB");
+
+            cvodes_check_flag(CVodeB(cvodes_mem_, (i > 0) ? ts_[i - 1] : t0_,
+                                     CV_NORMAL),
+                              "CVodeB");
+
+            // Currently unused, but I should probably check it. CVodeGetB sets
+            // it to the time that the ode successfully integrated back to.
+            // This should be equal to (i > 0) ? ts_[i - 1] : t0_
+            double tret;
+
+            cvodes_check_flag(CVodeGetB(cvodes_mem_, indexB, &tret,
+                                        cvodes_state_sens),
+                              "CVodeGetB");
+          }
+
+          // After integrating all the way back to t0, we finally have the
+          // the adjoints we wanted
+          // These are the dlog_density / d(initial_conditions[s]) adjoints
+          for (size_t s = 0; s < N_; s++) {
+            initial_v_[s]->adj_ += NV_Ith_S(cvodes_state_sens, s);
+          }
+
+          // These are the dlog_density / d(parameters[s]) adjoints
+          for (size_t s = 0; s < M_; s++) {
+            theta_v_[s]->adj_ += NV_Ith_S(cvodes_state_sens, N_ + s);
+          }
+        } catch (const std::exception& e) {
+          N_VDestroy_Serial(cvodes_state_sens);
+          throw;
+        }
+
+        // At some point in the future I should free memory
+        //  N_VDestroy_Serial(cvodes_state_sens);
+        //  CVodeFree(&cvodes_mem_);
+        //  delete cvodes_data_;
+      }
+    };
+  }
+}
+#endif

--- a/stan/math/rev/mat/functor/cvodes_utils.hpp
+++ b/stan/math/rev/mat/functor/cvodes_utils.hpp
@@ -17,6 +17,10 @@ namespace stan {
     inline void cvodes_silent_err_handler(int error_code, const char* module,
                                           const char* function, char *msg,
                                           void *eh_data) {
+      // I found it handy to make this non-silent to debug CVODES while I set up
+      // the adjoint sensitivity. I'm keeping this here for now
+      std::cout << "Error " << msg << " (" << error_code << ") in " <<
+        module << ", " << function << std::endl;
     }
 
     inline void cvodes_check_flag(int flag, const std::string& func_name) {

--- a/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
+++ b/test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp
@@ -25,11 +25,11 @@ void sho_value_test(F harm_osc,
                                     ts, promote_scalar<T_theta>(theta), x,
                                     x_int);
 
-  EXPECT_NEAR(0.995029, ode_res_vd[0][0].val(), 1e-5);
-  EXPECT_NEAR(-0.0990884, ode_res_vd[0][1].val(), 1e-5);
+  EXPECT_NEAR(0.995029, ode_res_vd.front()[0].val(), 1e-5);
+  EXPECT_NEAR(-0.0990884, ode_res_vd.front()[1].val(), 1e-5);
 
-  EXPECT_NEAR(-0.421907, ode_res_vd[99][0].val(), 1e-5);
-  EXPECT_NEAR(0.246407, ode_res_vd[99][1].val(), 1e-5);
+  EXPECT_NEAR(-0.421907, ode_res_vd.back()[0].val(), 1e-5);
+  EXPECT_NEAR(0.246407, ode_res_vd.back()[1].val(), 1e-5);
 }
 
 void sho_finite_diff_test(double t0) {
@@ -44,8 +44,10 @@ void sho_finite_diff_test(double t0) {
   y0.push_back(0.0);
 
   std::vector<double> ts;
-  for (int i = 0; i < 100; i++)
+  for (int i = 0; i < 9; i++)
     ts.push_back(t0 + 0.1 * (i + 1));
+
+  ts.push_back(t0 + 10.0);
 
   std::vector<double> x;
   std::vector<int> x_int;
@@ -73,8 +75,9 @@ void sho_data_finite_diff_test(double t0) {
 
 
   std::vector<double> ts;
-  for (int i = 0; i < 100; i++)
+  for (int i = 0; i < 9; i++)
     ts.push_back(t0 + 0.1 * (i + 1));
+  ts.push_back(t0 + 10.0);
 
   std::vector<double> x(3,1);
   std::vector<int> x_int(2,0);
@@ -117,6 +120,8 @@ TEST(StanAgradRevOde_integrate_ode, harmonic_oscillator_finite_diff) {
   sho_finite_diff_test(1.0);
   sho_finite_diff_test(-1.0);
 
+  // Comment out these three tests and things will pass
+  // If they're still in here, we get segfaults
   sho_data_finite_diff_test(0);
   sho_data_finite_diff_test(1.0);
   sho_data_finite_diff_test(-1.0);
@@ -135,8 +140,9 @@ TEST(StanAgradRevOde_integrate_ode, harmonic_oscillator_error) {
 
   double t0 = 0;
   std::vector<double> ts;
-  for (int i = 0; i < 100; i++)
+  for (int i = 0; i < 9; i++)
     ts.push_back(t0 + 0.1 * (i + 1));
+  ts.push_back(t0 + 10.0);
 
   std::vector<double> x(3,1);
   std::vector<int> x_int(2,0);
@@ -175,8 +181,9 @@ TEST(StanAgradRevOde_integrate_ode, lorenz_finite_diff) {
   std::vector<double> x;
   std::vector<int> x_int;
 
-  for (int i = 0; i < 100; i++)
-    ts.push_back(0.1*(i+1));
+  for (int i = 0; i < 9; i++)
+    ts.push_back(0.1 * (i + 1));
+  ts.push_back(10.0);
 
   test_ode_cvode(lorenz, t0, ts, y0, theta, x, x_int, 1e-8, 1e-1);
 }


### PR DESCRIPTION
I replaced some of the forward sensitivity stuff, but I think practically both sensitivity techniques would be exposed instead of just one or the other.

There are two big issues that need fixed with this now. One is a replacement for reserving a large autodiff stack (in core/vari.hpp) and the other is actually free-ing memory allocated in CVODES for the ode_vari.

Right now all the tests except for the ones in test/unit/math/rev/mat/functor/integrate_ode_bdf_rev_test.cpp that deal with data work.